### PR TITLE
Soapbox support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,13 @@ RUN mkdir -p /etc/pleroma /var/lib/pleroma/static /var/lib/pleroma/uploads && \
     adduser --system --shell /bin/false --home /opt/pleroma --group pleroma && \
     chown -vR pleroma /etc/pleroma /var/lib/pleroma
 
+
 COPY --chown=pleroma:pleroma --from=unzip /opt/pleroma/ /opt/pleroma/
 
 VOLUME [ "/etc/pleroma", "/var/lib/pleroma/uploads", "/var/lib/pleroma/static" ]
+
+ADD https://gitlab.com/soapbox-pub/soapbox-fe/-/jobs/artifacts/v1.2.3/download?job=build-production /tmp/soapbox-fe.zip
+RUN chown pleroma /tmp/soapbox-fe.zip
 
 USER pleroma
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN mkdir -p /etc/pleroma /var/lib/pleroma/static /var/lib/pleroma/uploads && \
     adduser --system --shell /bin/false --home /opt/pleroma --group pleroma && \
     chown -vR pleroma /etc/pleroma /var/lib/pleroma
 
-
 COPY --chown=pleroma:pleroma --from=unzip /opt/pleroma/ /opt/pleroma/
 
 VOLUME [ "/etc/pleroma", "/var/lib/pleroma/uploads", "/var/lib/pleroma/static" ]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ See the [documentation for `instance gen`](https://docs-develop.pleroma.social/b
 
 If you want to use RUM indexes, you need a [PostgreSQL container that supports them](https://github.com/jordemort/docker-postgres-rum/).
 
+If you would like to use the [SoapBox UI](https://soapbox.pub/), you can set an environment variable USE_SOAPBOX to "y".
+
 ## Persistence
 
 If you want your instance data to persist properly, you need to mount volumes on the following directories:

--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ The container will try to infer reasonable defaults for the rest of the variable
 | `--anonymize-uploads` | `ANONYMIZE_UPLOADS` | y |
 | `--dedupe-uploads` | `DEDUPE_UPLOADS` | y |
 
+
 See the [documentation for `instance gen`](https://docs-develop.pleroma.social/backend/administration/CLI_tasks/instance/) for more information.
 
 If you want to use RUM indexes, you need a [PostgreSQL container that supports them](https://github.com/jordemort/docker-postgres-rum/).
 
-If you would like to use the [SoapBox UI](https://soapbox.pub/), you can set an environment variable USE_SOAPBOX to "y".
+If you would like to use the [SoapBox UI](https://soapbox.pub/) instead of the normal Pleroma UI, you can set an environment variable USE_SOAPBOX to "y". SoapBox is a alternative to the normal Pleroma UI and emphasizes easier private branding and theming.
 
 ## Persistence
 

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
 
   pleroma:

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3.7'
 services:
 
   pleroma:
@@ -7,7 +8,7 @@ services:
     networks:
       pleromanet:
     ports:
-      - 127.0.0.1:4000:4000
+      - 4000:4000
     volumes:
       - config:/etc/pleroma
       - uploads:/var/lib/pleroma/uploads
@@ -16,6 +17,7 @@ services:
       DOMAIN: localhost
       ADMIN_EMAIL: chicken@example.com
       USE_RUM: "y"
+      USE_SOAPBOX: "n"
       POSTGRES_PASSWORD: hunter2
 
   postgres:

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     networks:
       pleromanet:
     ports:
-      - 4000:4000
+      - 127.0.0.1:4000:4000
     volumes:
       - config:/etc/pleroma
       - uploads:/var/lib/pleroma/uploads

--- a/run-pleroma.sh
+++ b/run-pleroma.sh
@@ -17,4 +17,9 @@ if [ "${USE_RUM:-n}" = "y" ] ; then
   pleroma_ctl migrate --migrations-path priv/repo/optional_migrations/rum_indexing/
 fi
 
+if [ "${USE_SOAPBOX:-n}" = "y" ]; then
+  unzip -o /tmp/soapbox-fe.zip -d /var/lib/pleroma
+  rm /tmp/soapbox-fe.zip
+fi
+
 exec pleroma start


### PR DESCRIPTION
I modified the docker-compose example, as well as the Dockerfile to support the SoapBox UI.

The downside is another payload in the docker build and also, on entrypoint, if the zip archive of soapbox-fe.zip exists (and the environment variable USE_SOAPBOX is set to "y", it will extract the archive into the appropriate location. I don't like that this adds to start up time (and the size of the container), but I can think of a better way given that the static volume where soapbox resides needs to be mounted for most use cases (which would remove the soapbox changes).

I also versioned the docker-compose file. The format wasn't working, for me, on the latest version of docker-compose.